### PR TITLE
Setting up Stage environment to validate on AWS

### DIFF
--- a/.github/actions/compile/action.yml
+++ b/.github/actions/compile/action.yml
@@ -44,14 +44,14 @@ runs:
     - name: Kas qcom world build
       shell: bash
       run: |
-        ${{inputs.kas}} build ci/${{ inputs.machine }}.yml${{ inputs.distro_yaml }}${{ inputs.kernel_yaml }}:ci/world.yml
+        ${{inputs.kas}} --runtime-args "--memory-swap=-1" build ci/${{ inputs.machine }}.yml${{ inputs.distro_yaml }}${{ inputs.kernel_yaml }}:ci/world.yml
         ci/kas-container-shell-helper.sh ci/yocto-pybootchartgui.sh
         mv $KAS_WORK_DIR/build/buildchart.svg buildchart-world.svg
 
     - name: Kas build images
       shell: bash
       run: |
-        ${{inputs.kas}} build ci/${{ inputs.machine }}.yml${{ inputs.distro_yaml }}${{ inputs.kernel_yaml }}
+        ${{inputs.kas}} --runtime-args "--memory-swap=-1" build ci/${{ inputs.machine }}.yml${{ inputs.distro_yaml }}${{ inputs.kernel_yaml }}
         ci/kas-container-shell-helper.sh ci/yocto-pybootchartgui.sh
         mv $KAS_WORK_DIR/build/buildchart.svg .
 
@@ -84,18 +84,18 @@ runs:
         find $deploy_dir/ -maxdepth 1 -type l \( -name boot-*.img -o -name *.rootfs.ext4.gz -o -name *.rootfs.qcomflash.tar.gz \) -exec cp -d {} $uploads_dir/ \;
         cp buildchart.svg kas-build.yml $uploads_dir/
 
-    - name: Upload private artifacts
-      uses: qualcomm-linux/upload-private-artifact-action@v1
-      id: upload_artifacts
-      with:
-        path: ./uploads
+    # - name: Upload private artifacts
+    #   uses: qualcomm-linux/upload-private-artifact-action@v1
+    #   id: upload_artifacts
+    #   with:
+    #     path: ./uploads
 
-    - name: Upload artifacts to S3 bucket
-      uses: qualcomm-linux/upload-private-artifact-action@aws-v1
-      with:
-        path: ./uploads
-        destination: ${{ github.repository_owner }}/${{ github.event.repository.name }}/${{ github.run_id }}-${{ github.run_attempt }}/
-        s3_bucket: qcom-prd-gh-artifacts
+    # - name: Upload artifacts to S3 bucket
+    #   uses: qualcomm-linux/upload-private-artifact-action@aws-v1
+    #   with:
+    #     path: ./uploads
+    #     destination: ${{ github.repository_owner }}/${{ github.event.repository.name }}/${{ github.run_id }}-${{ github.run_attempt }}/
+    #     s3_bucket: qcom-prd-gh-artifacts
 
     - name: "Print output"
       shell: bash

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -14,8 +14,8 @@ env:
 
 jobs:
   kas-setup:
-    if: github.repository == 'qualcomm-linux/meta-qcom'
-    runs-on: [self-hosted, qcom-u2404, amd64-ssd]
+    if: github.repository == 'qualcomm-linux-stg/aws-meta-qcom'
+    runs-on: [self-hosted, qcom-stg-u2404, amd64]
     steps:
       - name: Update kas-container
         run: |
@@ -43,8 +43,8 @@ jobs:
 
   yocto-run-checks:
     needs: kas-setup
-    if: github.repository == 'qualcomm-linux/meta-qcom'
-    runs-on: [self-hosted, qcom-u2404, amd64-ssd]
+    if: github.repository == 'qualcomm-linux-stg/aws-meta-qcom'
+    runs-on: [self-hosted, qcom-stg-u2404, amd64]
     steps:
       - uses: actions/checkout@v4
 
@@ -63,8 +63,8 @@ jobs:
 
   compile_warm_up:
     needs: [kas-setup, yocto-run-checks]
-    if: github.repository == 'qualcomm-linux/meta-qcom'
-    runs-on: [self-hosted, qcom-u2404, amd64-ssd]
+    if: github.repository == 'qualcomm-linux-stg/aws-meta-qcom'
+    runs-on: [self-hosted, qcom-stg-u2404, amd64]
     strategy:
       fail-fast: true
       matrix:
@@ -99,8 +99,8 @@ jobs:
 
   compile:
     needs: compile_warm_up
-    if: github.repository == 'qualcomm-linux/meta-qcom'
-    runs-on: [self-hosted, qcom-u2404, amd64-ssd]
+    if: github.repository == 'qualcomm-linux-stg/aws-meta-qcom'
+    runs-on: [self-hosted, qcom-stg-u2404, amd64]
     outputs:
       url: ${{ steps.compile_kas.outputs.url }}
     strategy:
@@ -167,7 +167,7 @@ jobs:
 
   publish_summary:
     needs: compile
-    runs-on: [self-hosted, qcom-u2404, amd64-ssd]
+    runs-on: [self-hosted, qcom-stg-u2404, amd64]
     steps:
       - name: 'Download build URLs'
         uses: actions/download-artifact@v4
@@ -201,5 +201,3 @@ jobs:
           overwrite: true
           name: build_url
           path: build_url
-
-

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -1,10 +1,11 @@
 name: Nightly Build
 
 on:
-  schedule:
-  # NOTE - changes to the cron spec should be pushed by https://github.com/quic-yocto-ci
-  # so that build notification emails will be sent out properly.
-  - cron: "22 1 * * *"   # daily job - pick a random "minute"  - top of hour can be busy in github
+  # schedule:
+  # # NOTE - changes to the cron spec should be pushed by https://github.com/quic-yocto-ci
+  # # so that build notification emails will be sent out properly.
+  # - cron: "22 1 * * *"   # daily job - pick a random "minute"  - top of hour can be busy in github
+  workflow_dispatch
 
 permissions:
   checks: write

--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   repolinter:
-    if: github.repository == 'qualcomm-linux/meta-qcom'
+    if: github.repository == 'qualcomm-linux-stg/aws-meta-qcom'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo


### PR DESCRIPTION
This setup will help to validate the meta-qcom GH workflows, end to end on AWS Stage environment.

    * Created a fork of meta-qcom as "aws-meta-qcom" under qualcomm-linux-stg organization.
    * Created a new branch as "qli-validation" to update the workflow settings
    * modified build-yocto.yml to use "aws-meta-qcom" repo
    * Remove nightly build schedule and updated with on demand build
    * Commented out the upload artifact step from action.yml
    * changed runner label to use non SSD instance
    * Install ZRAM-Tools and configure to use 50% of RAM
    * Updating Kas_container with runtime argument as --memory-swap=-1