### PR TITLE
linux-qcom-6.18 : update to tag qcom-6.18.y-20260611 v6.18.25

### DIFF
--- a/recipes-kernel/linux/linux-qcom_6.18.bb
+++ b/recipes-kernel/linux/linux-qcom_6.18.bb
@@ -8,14 +8,14 @@ inherit kernel cml1
 
 COMPATIBLE_MACHINE = "(qcom)"
 
-LINUX_VERSION ?= "6.18.25"
+LINUX_VERSION ?= "6.18.30"
 
 PV = "${LINUX_VERSION}"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/linux-qcom-6.18:"
 
-# tag:qcom-6.18.y-20260515
-SRCREV ?= "9a4537ba60cc7332c642471323e32f85df771053"
+# tag:qcom-6.18.y-20260611
+SRCREV ?= "d58ad5c480fa06f04fff90d42ad0367ea093bc7f"
 
 SRCBRANCH ?= "nobranch=1"
 SRCBRANCH:class-devupstream ?= "branch=qcom-6.18.y"


### PR DESCRIPTION
Move to the latest linux-qcom-6.18 release tag qcom-6.18.y-20260611

Changelog:
FROMLIST: misc: fastrpc: Add polling mode support for fastRPC driver
FROMLIST: misc: fastrpc: Expand context ID mask for DSP polling mode support
FROMLIST: misc: fastrpc: Replace hardcoded ctxid mask with GENMASK
FROMLIST: misc: fastrpc: Move fdlist to invoke context structure
Revert "FROMLIST: misc: fastrpc: Move fdlist to invoke context structure"
Revert "FROMLIST: misc: fastrpc: Add polling mode support for fastRPC driver"
QCLINUX: arm64: configs: qcom.config: Enable LZ4 backend for zram
FROMLIST: drm/panel: add Ilitek ILI7807S panel driver
FROMLIST: dt-bindings: display: panel: add Ilitek ILI7807S panel controller
FROMLIST: arm64: dts: qcom: talos-evk: fix sdhc_2 vqmmc-supply for UHS-I mode
PENDING: arm64: dts: qcom: lemans: Add TSC node in staging dtso
PENDING: arm64: configs: Enable Qualcomm TSCSS driver support
PENDING: ptp: Add support for Qualcomm TSCSS hardware
PENDING: dt-bindings: ptp: Add support for Qualcomm TSCSS module
FROMLIST: rpmsg: glink: Make glink smem interrupt wakeup capable
FROMLIST: soc: qcom: ubwc: Add Shikra UBWC config
FROMLIST: dt-bindings: display: msm: qcm2290: Add Shikra MDSS
FROMLIST: drm/msm/dp: Introduce poll_hpd_irq callback for MST sideband handling
FROMLIST: drm/msm/dp: add HPD callback for dp MST
FROMLIST: drm/msm/dp: add connector abstraction for DP MST
FROMLIST: drm/msm/dp: add dp_mst_drm to manage DP MST bridge operations
Revert "FROMLIST: drm/msm/dp: add dp_mst_drm to manage DP MST bridge operations"
Revert "FROMLIST: drm/msm/dp: add connector abstraction for DP MST"
Revert "FROMLIST: drm/msm/dp: add HPD callback for dp MST"
QCLINUX: arm64: dts: qcom: add IFE Lite CPAS paths to purwa camera dtsi
PENDING: arm64: dts: qcom: glymur: add TGU and ETR in staging dtso
PENDING: arm64: dts: qcom: hamoa: add TGU in staging dtso
FROMLIST: arm64: dts: qcom: shikra-iqs-evk-imx577-camera: Add DT overlay
FROMLIST: arm64: dts: qcom: shikra-cqm-evk-imx577-camera: Add DT overlay
FROMLIST: arm64: dts: qcom: shikra: Add pin configuration for mclks
FROMLIST: arm64: dts: qcom: shikra: Add CCI definitions
FROMLIST: arm64: dts: qcom: shikra: Add CAMSS node
FROMLIST: media: qcom: camss: add support for QCM2390 camss
FROMLIST: dt-bindings: i2c: qcom-cci: Document Shikra compatible
FROMLIST: dt-bindings: media: qcom: Add Shikra CAMSS compatible
FROMLIST: arm64: dts: qcom: Add GP M/N clock controller node for SA8775P and QCS8300
FROMLIST: arm64: dts: qcom: Add gp_mn pin state for GP M/N clock output
FROMLIST: pinctrl: qcom: Add gp_mn mux function for QCS8300, SA8775P and SC7280
FROMLIST: clk: qcom: Add a driver for PDM GP_MN fractional clock divider
QCLINUX: arm64: dts: qcom: monaco-evk: disable unused camera regulators
FROMLIST: arm64: dts: qcom: shikra: Add support for AudioCoreCC node
FROMLIST: clk: qcom: Add Audio Core clock controller support on Qualcomm Shikra SoC
FROMLIST: dt-bindings: clock: qcom: Add Qualcomm Shikra Audio Core Clock Controller
FROMLIST: clk: qcom: common: Register reset controller only when resets are present
FROMLIST: clk: qcom: gcc-shikra: Add USB3 DP PHY reset and LPASS clocks
FROMLIST: dt-bindings: clock: qcom: Add the definition for the USB3 DP PHY reset
FROMLIST: misc: fastrpc: Add cache maintenance for non-coherent platforms
PENDING: arm64: dts: qcom: talos-evk: add QPS615 m.2 ethernet staging overlay
FROMLIST: drm/msm/a6xx: Fix stale rpmh votes after suspend
FROMLIST: dt-bindings: clock: qcom: Add bindings for PDM GP_MN clock divider
QCLINUX: arm64: configs: qcom.config: Enable CONFIG_SWIOTLB_DYNAMIC
FROMLIST: arm64: dts: qcom: shikra: Add support for DISPCC/GPUCC nodes
FROMLIST: arm64: dts: qcom: agatti: Add DSI1 PHY and sleep clocks to DISPCC node
FROMLIST: clk: qcom: Add support for Qualcomm GPU Clock Controller on Shikra
FROMLIST: clk: qcom: gpucc-qcm2290: Update GDSC *wait_val values and flags
FROMLIST: clk: qcom: gpucc-qcm2290: Park RCG's clk source at XO during disable
FROMLIST: clk: qcom: gpucc-qcm2290: Move to the latest common qcom_cc_probe() model
FROMLIST: clk: qcom: dispcc-qcm2290: Update GDSC *wait_val values and flags
FROMLIST: clk: qcom: dispcc-qcm2290: Switch to DT index based clk lookup
FROMLIST: clk: qcom: dispcc-qcm2290: Move to the latest common qcom_cc_probe() model
FROMLIST: dt-bindings: clock: qcom: Add Qualcomm Shikra GPU clock controller
FROMLIST: dt-bindings: clock: qcom: Add Qualcomm Shikra Display clock controller
FROMLIST: dt-bindings: clock: qcom,qcm2290-dispcc: Add DSI1 PHY and sleep clocks
FROMLIST: clk: qcom: gcc-qcm2290: Keep the critical clocks always-on from probe
clk: qcom: Revert older series Shikra GPUCC/DISPCC changes
FROMLIST: PCI: qcom: Add D3cold support
FROMLIST: PCI: dwc: Use common D3cold eligibility helper in suspend path
FROMLIST: PCI: qcom: Power down PHY via PARF_PHY_CTRL before disabling rails/clocks
FROMLIST: PCI: qcom: Add .get_ltssm() helper
FROMLIST: PCI: host-common: Add helper to determine host bridge D3cold eligibility
FROMLIST: PCI: dwc: Fail dw_pcie_host_init() if dw_pcie_wait_for_link() returns -ETIMEDOUT
FROMLIST: PCI: dwc: Rework the error print of dw_pcie_wait_for_link()
FROMLIST: PCI: dwc: Rename and move ltssm_status_string() to pcie-designware.c
FROMLIST: PCI: dwc: Return -EIO from dw_pcie_wait_for_link() if device is not active
FROMLIST: PCI: dwc: Return -ENODEV from dw_pcie_wait_for_link() if device is not found
FROMLIST: scsi: ufs: ufs-qcom: Enable SKIP DEVICE RESET Quirk
FROMLIST: scsi: ufs: core: Add UFSHCD_QUIRK_SKIP_DEVICE_RESET quirk
QCLINUX: qcom.config: Enable CPU caches RAS
FROMLIST: misc: fastrpc: fix context leak and hang on signal-interrupted invoke
QCLINUX: arm64: dts: qcom: Change Purwa camera firmware path
FROMLIST: arm64: dts: qcom: talos: Add GEM_NOC interconnect for adreno SMMU
FROMLIST: arm64: dts: qcom: monaco: Add GEM_NOC interconnect for adreno SMMU
FROMLIST: arm64: dts: qcom: lemans: Add GEM_NOC interconnect for adreno SMMU
FROMLIST: arm64: dts: qcom: kodiak: Add GEM_NOC interconnect for adreno SMMU
FROMLIST: arm64: dts: qcom: monaco: add AEST error nodes
FROMLIST: arm64: dts: qcom: lemans: add AEST error nodes
FROMLIST: ras: aest: Add DT frontend for ARM AEST RAS error sources
FROMLIST: Bluetooth: qca: combine NVM and calibration data for QCC2072
FROMLIST: arm64: dts: qcom: Add M.2 QCC2072 support on qcs6490-rb3gen2 industrial mezzanine
FROMLIST: Bluetooth: qca: add QCC2072 support
FROMLIST: dt-bindings: net: bluetooth: qcom: document QCC2072
FROMLIST: Bluetooth: hci_qca: Use 100 ms SSR delay for rampatch and NVM loading
FROMLIST: mmc: sdhci-msm: Set ice clk rate
FROMLIST: arm64: dts: qcom: purwa-iot-evk: Update TSENS thermal zone
FROMLIST: serial: qcom_geni: Fix RX DMA stall when SE_DMA_RX_LEN_IN is zero
FROMLIST: misc: fastrpc: Allow fastrpc_buf_free() to accept NULL
FROMLIST: misc: fastrpc: Allocate entire reserved memory for Audio PD in probe
FROMLIST: misc: fastrpc: Fail Audio PD init when reserved memory is missing
FROMLIST: misc: fastrpc: Remove buffer from list prior to unmap operation
FROMLIST: misc: fastrpc: Fix initial memory allocation for Audio PD memory pool
Revert "FROMLIST: misc: fastrpc: Fix initial memory allocation for Audio PD memory pool"
Revert "FROMLIST: misc: fastrpc: Remove buffer from list prior to unmap operation"
Revert "FROMLIST: misc: fastrpc: Allocate entire reserved memory for Audio PD in probe"
Revert "FROMLIST: misc: fastrpc: Allow fastrpc_buf_free() to accept NULL"
FROMLIST: media: iris: switch to hardware mode after firmware boot
FROMLIST: media: iris: optimize COMV buffer allocation for VPU3x and VPU4x
FROMLIST: arm64: dts: qcom: qcs615-ride: fix sdhc_2 vqmmc supply for UHS-I mode
FROMLIST: media: iris: Add Gen2 firmware autodetect and fallback
FROMLIST: media: iris: Initialize HFI ops after firmware load in core init
FROMGIT: media: qcom: iris: extract firmware description data
FROMGIT: media: qcom: iris: use new firmware name for SM8250
FROMGIT: media: qcom: iris: split platform data from firmware data
FROMGIT: media: qcom: iris: split firmware_data from raw platform data
FROMGIT: media: qcom: iris: drop hw_response_timeout_val from platform data
FROMGIT: media: qcom: iris: move get_instance to iris_hfi_sys_ops
FROMGIT: media: qcom: iris: merge hfi_response_ops and hfi_command_ops
FROMGIT: media: qcom: iris: split HFI session ops from core ops
FROMGIT: media: qcom: iris: don't use function indirection in gen2-specific code
FROMGIT: media: qcom: iris: use common set_preset_registers function
FROMGIT: media: qcom: iris: drop pas_id from the iris_platform_data struct
FROMGIT: media: iris: drop remnants of UBWC configuration
FROMGIT: media: iris: don't specify max_channels in the source code
FROMGIT: media: iris: don't specify bank_spreading in the source code
FROMGIT: media: iris: don't specify ubwc_swizzle in the source code
FROMGIT: media: iris: don't specify highest_bank_bit in the source code
FROMGIT: media: iris: don't specify min_acc_length in the source code
FROMGIT: media: iris: retrieve UBWC platform configuration
FROMGIT: soc: qcom: ubwc: add helpers to get programmable values
FROMGIT: soc: qcom: ubwc: add helper to get min_acc length
QCLINUX: arm64: dts: qcom: Fix GPIO free and acquire logic
PENDING: arm64: defconfig: select INTERCONNECT_QCOM_SHIKRA as built-in
QCLINUX: arm64: dts: qcom: add purwa CAMX EL2 overlay
FROMLIST: arm64: dts: qcom: shikra: enable WiFi on EVK boards
FROMLIST: arm64: dts: qcom: shikra: add WiFi node support
FROMLIST: arm64: dts: qcom: shikra: Enable BT support on EVK boards
FROMLIST: arm64: dts: qcom: shikra: Enable TSENS and thermal zones
FROMLIST: arm64: dts: qcom: shikra-iqs: Enable CDSP, LPAICP and MPSS
FROMLIST: arm64: dts: qcom: shikra-cqs: Enable CDSP, LPAICP and MPSS
FROMLIST: arm64: dts: qcom: shikra-cqm: Enable CDSP, LPAICP and MPSS
FROMLIST: arm64: dts: qcom: shikra: Add CDSP, LPAICP, MPSS remoteproc PAS nodes
FROMLIST: arm64: dts: qcom: shikra: Add SMP2P nodes
FROMLIST: arm64: dts: qcom: shikra: Add CPU OPP tables to scale DDR/L3
FROMLIST: arm64: dts: qcom: shikra: Add EPSS L3 interconnect provider node
FROMLIST: arm64: dts: qcom: shikra: Add DDR BWMON support
FROMLIST: arm64: dts: qcom: shikra: Add cpufreq scaling node
FROMLIST: arm64: dts: qcom: Add QUPv3 configuration for Shikra
FROMLIST: dt-bindings: interconnect: qcom-bwmon: Add Shikra cpu-bwmon compatible
FROMLIST: dt-bindings: dma: qcom,gpi: Document GPI DMA engine for Shikra SoC
FROMLIST: interconnect: qcom: Add EPSS L3 scaling support for Shikra SoC
FROMLIST: dt-bindings: interconnect: qcom,shikra-epss-l3: Add EPSS L3 DT binding
FROMLIST: pinctrl: qcom: Unconditionally mark gpio as wakeup enable
FROMLIST: soc: qcom: smem: Switch partitions to xarray
FROMLIST: media: venus: prefer iris driver for qcm2290 when IRIS is enabled
FROMLIST: dt-bindings: media: qcom,qcm2290-venus: document shikra Iris compatible
FROMLIST: dt-bindings: arm-smmu: Add adreno-smmu compatible for Qualcomm Shikra
FROMLIST: regulator: qcom_usb_vbus: add support for qcom,pm4125-vbus-reg
FROMLIST: dt-bindings: regulator: qcom,usb-vbus-regulator: add qcom,pm4125-vbus-reg
FROMLIST: arm64: dts: qcom: shikra: Add ICE, TRNG and QCE nodes
FROMLIST: dt-bindings: dma: qcom,bam-dma: Increase iommus maxItems to seven
FROMLIST: dt-bindings: crypto: qcom-qce: Document the Shikra crypto engine
FROMLIST: dt-bindings: crypto: qcom,prng: Document Shikra TRNG
FROMLIST: dt-bindings: crypto: qcom,inline-crypto-engine: Document Shikra ICE
FROMLIST: dt-bindings: thermal: qcom-tsens: Document the Shikra Temperature Sensor
FROMLIST: remoteproc: qcom: pas: Add Shikra remoteproc support
FROMLIST: dt-bindings: remoteproc: qcom,shikra-pas: Document Shikra PAS remoteprocs
FROMLIST: clk: qcom: Add support for GPU Clock Controller on Shikra
FROMLIST: clk: qcom: Add support for Display Clock Controller on Shikra
FROMLIST: dt-bindings: clock: qcom: Add Shikra GPU clock controller
FROMLIST: dt-bindings: clock: qcom: Add Shikra Display clock controller
FROMLIST: arm64: dts: qcom: Add Shikra EVK boards
FROMLIST: arm64: dts: qcom: Add Shikra IQ2390S SoM platform
FROMLIST: arm64: dts: qcom: Add Shikra CQ2390M SoM platform
FROMLIST: arm64: dts: qcom: Introduce Shikra SoC base dtsi
FROMLIST: dt-bindings: arm: qcom: Document Shikra and its EVK boards
FROMLIST: dt-bindings: mmc: sdhci-msm: Document the Shikra compatible
FROMLIST: dt-bindings: cache: qcom,llcc: Document Shikra LLCC
FROMLIST: dt-bindings: nvmem: qcom,qfprom: Add Shikra compatible
FROMLIST: dt-bindings: watchdog: qcom-wdt: Document Shikra watchdog
FROMLIST: dt-bindings: mfd: qcom,tcsr: Add compatible for Shikra
FROMLIST: dt-bindings: firmware: qcom,scm: Document SCM on Shikra SoC
FROMLIST: cpufreq: qcom: Add cpufreq scaling support for Qualcomm Shikra SoC
FROMLIST: dt-bindings: cpufreq: Document Qualcomm Shikra SoC EPSS
FROMLIST: dt-bindings: sram: Document qcom,shikra-imem compatible
FROMLIST: dt-bindings: arm-smmu: qcom: Add compatible for Qualcomm Shikra SoC
FROMLIST: dt-bindings: usb: qcom,snps-dwc3: Add Shikra compatible
FROMLIST: phy: qcom: qmp-usbc: Add qmp configuration for Shikra
FROMLIST: phy: qcom-qusb2: Add support for Shikra
FROMLIST: dt-bindings: phy: qcom,msm8998-qmp-usb3-phy: Add support for Shikra
FROMLIST: dt-bindings: phy: qcom,qusb2: Document QUSB2 Phy for Shikra
FROMLIST: dt-bindings: mailbox: qcom: Add Shikra APCS compatible
FROMLIST: dt-bindings: remoteproc: Add Shikra RPM processor compatible
FROMLIST: dt-bindings: soc: qcom: smd-rpm: Add Shikra rpm-smd compatible
FROMLIST: clk: qcom: Add Global clock controller support on Qualcomm Shikra SoC
FROMLIST: clk: qcom: smd-rpm: Add support for RPM clocks on Qualcomm Shikra SoC
FROMLIST: dt-bindings: clock: qcom: Add Qualcomm Shikra SoC Global Clock Controller
FROMLIST: dt-bindings: clock: qcom,rpmcc: Add Qualcomm Shikra SoC RPMCC
FROMLIST: pmdomain: qcom: rpmpd: Add Shikra RPM Power Domains
FROMLIST: dt-bindings: power: qcom,rpmpd: document the Shikra RPM Power Domains
FROMLIST: regulator: qcom_smd: Add PM8150 regulators
FROMLIST: dt-bindings: regulator: qcom,smd-rpm-regulator: Document PM8150 IC
FROMLIST: interconnect: qcom: add Shikra interconnect provider driver
FROMLIST: dt-bindings: interconnect: document the RPM Network-On-Chip interconnect in Shikra SoC
FROMLIST: pinctrl: qcom: Add Shikra pinctrl driver
FROMLIST: dt-bindings: pinctrl: qcom: Document Shikra Top Level Mode Multiplexer
FROMLIST: soc: qcom: socinfo: Add SoC ID for Shikra IoT variants
FROMLIST: dt-bindings: arm: qcom,ids: Add SoC ID for Shikra IoT variants
FROMLIST: wifi: ath11k: raise max vdevs to 4 on hardware with P2P and dual-station support
QCLINUX: arm64: configs: Add Linux software RAID support
FROMLIST: misc: fastrpc: fix use-after-free of fastrpc_user in workqueue context
Revert "FROMLIST: misc: fastrpc: Add reference counting for fastrpc_user structure"
FROMLIST: arm64: dts: qcom: qcs6490-rb3gen2: Add WCD headset playback and record for qcs6490-rb3gen2 industrial mezzanine
FROMLIST: arm64: dts: qcom: lemans: enable EUD support
FROMLIST: dt-bindings: arm: ras: Introduce bindings for ARM AEST
FROMLIST: ras: aest: Add panic_on_ue module parameter
FROMLIST: ras: aest: Skip unimplemented records in debugfs
FROMLIST: ras: aest: Fix CE/UE error counts not incrementing in debugfs
FROMLIST: ras: aest: Fix shared processor node handling and error log messages
FROMLIST: trace, ras: add ARM RAS extension trace event
FROMLIST: ras: AEST: support vendor node CMN700
FROMLIST: ras: AEST: Add framework to process AEST vendor node
FROMLIST: ras: AEST: Introduce AEST inject interface to test AEST driver
FROMLIST: ras: AEST: Allow configuring CE threshold via debugfs
FROMLIST: ras: AEST: Add error count tracking and debugfs interface
FROMLIST: ras: AEST: Introduce AEST driver sysfs interface
FROMLIST: ras: AEST: Add cpuhp callback
FROMLIST: ras: AEST: Enable and register IRQs
FROMLIST: ras: AEST: Support CE threshold of error record
FROMLIST: ras: AEST: Support RAS Common Fault Injection Model Extension
FROMLIST: ras: AEST: Probe RAS system architecture version
FROMLIST: ras: AEST: Unify the read/write interface for system and MMIO register
FROMLIST: ras: AEST: support different group format
FROMLIST: ras: AEST: Add probe/remove for AEST driver
FROMLIST: ACPI/AEST: Parse the AEST table
FROMLIST: Bluetooth: hci_qca: Fix missing wakeup during SSR memdump handling
FROMLIST: Bluetooth: hci_qca: Convert timeout from jiffies to ms
FROMLIST: wifi: ath12k: enable threaded NAPI when DP IRQ affinity is unavailable
FROMLIST: genirq: export irq_can_set_affinity() for module drivers
FROMLIST: iommu/arm-smmu: Add interconnect bandwidth voting support
FROMLIST: dt-bindings: iommu: arm,smmu: Document optional interconnects property
QCLINUX: arm64: dts: qcom: add hamoa CAMX EL2 overlay
FROMLIST: arm64: dts: qcom: monaco: fix wrong connection for the replicator
BACKPORT: arm64: dts: qcom: monaco: Add CTCU and ETR nodes
BACKPORT: dt-bindings: arm: add CTCU device for monaco
Linux 6.18.30
ksmbd: validate inherited ACE SID length
x86/CPU/AMD: Prevent improper isolation of shared resources in Zen2's op cache
rust: pin-init: fix incorrect accessor reference lifetime
net: stmmac: Prevent NULL deref when RX memory exhausted
net: stmmac: rename STMMAC_GET_ENTRY() -> STMMAC_NEXT_ENTRY()
crypto: caam - guard HMAC key hex dumps in hash_digest_key
printk: add print_hex_dump_devel()
erofs: fix unsigned underflow in z_erofs_lz4_handle_overlap()
erofs: tidy up z_erofs_lz4_handle_overlap()
hfsplus: fix held lock freed on hfsplus_fill_super()
hfsplus: fix uninit-value by validating catalog record size
firmware: exynos-acpm: Drop fake 'const' on handle pointer
mm, swap: speed up hibernation allocation and writeout
crypto: qat - fix firmware loading failure for GEN6 devices
crypto: qat - fix indentation of macros in qat_hal.c
mmc: core: Optimize time for secure erase/trim for some Kingston eMMCs
mmc: core: Add quirk for incorrect manufacturing date
mmc: core: Adjust MDT beyond 2025
octeon_ep_vf: add NULL check for napi_build_skb()
hwmon: (powerz) Avoid cacheline sharing for DMA buffer
dma-mapping: add __dma_from_device_group_begin()/end()
fbdev: defio: Disconnect deferred I/O from the lifetime of struct fb_info
mm/damon/core: disallow non-power of two min_region_sz on damon_start()
bpf: Fix use-after-free in arena_vm_close on fork
io_uring/tw: serialize ctx->retry_llist with ->uring_lock
io_uring/kbuf: support min length left for incremental buffers
LoongArch: Use per-root-bridge PCIH flag to skip mem resource fixup
LoongArch: KVM: Use kvm_set_pte() in kvm_flush_pte()
LoongArch: KVM: Move unconditional delay into timer clear scenery
LoongArch: KVM: Fix HW timer interrupt lost when inject interrupt by software
LoongArch: KVM: Fix "unreliable stack" for kvm_exc_entry
LoongArch: KVM: Cap KVM_CAP_NR_VCPUS by KVM_CAP_MAX_VCPUS
LoongArch: Fix potential ADE in loongson_gpu_fixup_dma_hang()
KVM: arm64: Fix pin leak and publication ordering in __pkvm_init_vcpu()
KVM: arm64: Fix FEAT_Debugv8p9 to check DebugVer, not PMUVer
KVM: arm64: Fix FEAT_SPE_FnE to use PMSIDR_EL1.FnE, not PMSVer
KVM: arm64: Fix initialisation order in __pkvm_init_finalise()
KVM: arm64: vgic: Fix IIDR revision field extracted from wrong value
KVM: arm64: Wake-up from WFI when iqrchip is in userspace
f2fs: fix fsck inconsistency caused by FGGC of node block
f2fs: fix inline data not being written to disk in writeback path
f2fs: refactor f2fs_move_node_folio function
f2fs: fix uninitialized kobject put in f2fs_init_sysfs()
f2fs: fix node_cnt race between extent node destroy and writeback
f2fs: fix incorrect multidevice info in trace_f2fs_map_blocks()
f2fs: fix incorrect file address mapping when inline inode is unwritten
f2fs: fix fsck inconsistency caused by incorrect nat_entry flag usage
f2fs: fix fiemap boundary handling when read extent cache is incomplete
f2fs: add READ_ONCE() for i_blocks in f2fs_update_inode()
mptcp: pm: ADD_ADDR rtx: return early if no retrans
mptcp: pm: ADD_ADDR rtx: resched blocked ADD_ADDR quicker
mptcp: pm: ADD_ADDR rtx: free sk if last
mptcp: pm: ADD_ADDR rtx: always decrease sk refcount
mptcp: pm: ADD_ADDR rtx: fix potential data-race
mptcp: pm: ADD_ADDR rtx: allow ID 0
mptcp: pm: kernel: correctly retransmit ADD_ADDR ID 0
mptcp: pm: prio: skip closed subflows
mptcp: fix scheduling with atomic in timestamp sockopt
mptcp: fix rx timestamp corruption on fastopen
mptcp: sockopt: increase seq in mptcp_setsockopt_all_sf
mptcp: sockopt: set timestamp flags on subflow socket, not msk
mptcp: use MPTCP_RST_EMPTCP for ACK HMAC validation failure
mptcp: use MPJoinSynAckHMacFailure for SynAck HMAC failure
mptcp: fastclose msk when linger time is 0
selftests: mptcp: pm: restrict 'unknown' check to pm_nl_ctl
selftests: mptcp: check output: catch cmd errors
sched_ext: idle: Recheck prev_cpu after narrowing allowed mask
RDMA/vmw_pvrdma: Fix double free on pvrdma_alloc_ucontext() error path
RDMA/rxe: Reject unknown opcodes before ICRC processing
RDMA/rxe: Reject non-8-byte ATOMIC_WRITE payloads
RDMA/ocrdma: Don't NULL deref uctx on errors in ocrdma_copy_pd_uresp()
RDMA/mlx5: Fix error path fall-through in mlx5_ib_dev_res_srq_init()
RDMA/mlx4: Fix resource leak on error in mlx4_ib_create_srq()
RDMA/mlx4: Fix mis-use of RCU in mlx4_srq_event()
RDMA/mana: Validate rx_hash_key_len
RDMA/mana: Remove user triggerable WARN_ON() in mana_ib_create_qp_rss()
RDMA/mana: Fix mana_destroy_wq_obj() cleanup in mana_ib_create_qp_rss()
RDMA/mana: Fix error unwind in mana_ib_create_qp_rss()
RDMA/ionic: Fix typo in format string
RDMA/ionic: bound node_desc sysfs read with %.64s
perf/x86/intel: Always reprogram ACR events to prevent stale masks
powerpc/xive: fix kmemleak caused by incorrect chip_data lookup
power: supply: max17042: avoid overflow when determining health
PCI/ASPM: Fix pci_clear_and_set_config_dword() usage
PCI/AER: Stop ruling out unbound devices as error source
PCI/AER: Clear only error bits in PCIe Device Status
PCI: Update saved_config_space upon resource assignment
mm/damon/sysfs-schemes: protect memcg_path kfree() with damon_sysfs_lock
mm/damon/stat: detect and use fresh enabled value
KVM: x86: Do IRR scan in __kvm_apic_update_irr even if PIR is empty
KVM: x86: check for nEPT/nNPT in slow flush hypercalls
smb: client: validate dacloffset before building DACL pointers
smb: client: use kzalloc to zero-initialize security descriptor buffer
smb/client: fix out-of-bounds read in symlink_data()
smb/client: fix out-of-bounds read in smb2_compound_op()
scsi: mpt3sas: Limit NVMe request size to 2 MiB
s390/debug: Reject zero-length input before trimming a newline
s390/debug: Reject zero-length input in debug_input_flush_fn()
riscv: kvm: fix vector context allocation leak
RDMA/hns: Fix unlocked call to hns_roce_qp_remove()
psp: strip variable-length PSP header in psp_dev_rcv()
pmdomain: core: Fix detach procedure for virtual devices in genpd
openvswitch: vport: fix self-deadlock on release of tunnel ports
nvmet: avoid recursive nvmet-wq flush in nvmet_ctrl_free
nvmet-tcp: fix race between ICReq handling and queue teardown
nvme-apple: drop invalid put of admin queue reference count
md/raid10: fix divide-by-zero in setup_geo() with zero far_copies
libceph: Fix slab-out-of-bounds access in auth message processing
lib/scatterlist: fix temp buffer in extract_user_to_sg()
lib/scatterlist: fix length calculations in extract_kvec_to_sg
lib/crypto: mpi: Fix integer underflow in mpi_read_raw_from_sgl()
iommu/arm-smmu-v3: Add a missing dma_wmb() for hitless STE update
iommu/vt-d: Block PASID attachment to nested domain with dirty tracking
iommufd: Fix return value of iommufd_fault_fops_write()
isofs: validate block number from NFS file handle in isofs_export_iget
isofs: validate Rock Ridge CE continuation extent against volume size
dm-verity-fec: correctly reject too-small hash devices
dm-verity-fec: correctly reject too-small FEC devices
eventfs: Hold eventfs_mutex and SRCU when remount walks events
dm: fix a buffer overflow in ioctl processing
dm: don't report warning when doing deferred remove
dm-thin: fix metadata refcount underflow
btrfs: fix missing last_unlink_trans update when removing a directory
btrfs: fix double free in create_space_info() error path
ASoC: qcom: q6apm: remove child devices when apm is removed
ASoC: qcom: q6apm-lpass-dai: Fix multiple graph opens
ASoC: qcom: q6apm-dai: reset queue ptr on trigger stop
ASoC: Intel: bytcr_wm5102: Fix MCLK leak on platform_clock_control error
ASoC: fsl_easrc: fix comment typo
ASoC: ES8389: convert to devm_clk_get_optional() to get clock
ASoC: amd: yc: Add HP OMEN Gaming Laptop 16-ap0xxx product line in quirk table
cpuidle: powerpc: avoid double clear when breaking snooze
clk: microchip: mpfs-ccc: fix out of bounds access during output registration
clk: imx: imx8-acm: fix flags for acm clocks
tracing/probes: Limit size of event probe to 3K
spi: topcliff-pch: fix use-after-free on unbind
spi: topcliff-pch: fix controller deregistration
thermal/drivers/sprd: Fix raw temperature clamping in sprd_thm_rawdata_to_temp
thermal/drivers/sprd: Fix temperature clamping in sprd_thm_temp_to_rawdata
thermal: core: Free thermal zone ID later during removal
udf: reject descriptors with oversized CRC length
tracefs: Fix default permissions not being applied on initial mount
spi: microchip-core-qspi: control built-in cs manually
spi: microchip-core-qspi: don't attempt to transmit during emulated read-only dual/quad operations
spi: microchip-core-qspi: fix controller deregistration
ice: fix double free in ice_sf_eth_activate() error path
ibmveth: Disable GSO for packets with small MSS
hv_sock: Return -EIO for malformed/short packets
hv_sock: Report EOF instead of -EIO for FIN
hv_sock: fix ARM64 support
hv: Select CONFIG_SYSFB only for CONFIG_HYPERV_VMBUS
gpio: of: clear OF_POPULATED on hog nodes in remove path
extcon: ptn5150: handle pending IRQ events during system resume
cifs: change_conf needs to be called for session setup
cifs: abort open_cached_dir if we don't request leases
block: only read from sqe on initial invocation of blkdev_uring_cmd()
block: add pgmap check to biovec_phys_mergeable
pmdomain: mediatek: fix use-after-free in scpsys_get_bus_protection_legacy()
arm64/fpsimd: ptrace: zero target's fpsimd_state, not the tracer's
af_unix: Reject SIOCATMARK on non-stream sockets
hwmon: (corsair-psu) Close HID device on probe errors
clk: rk808: fix OF node reference imbalance
hwmon: (ltc2992) Fix u32 overflow in power read path
hwmon: (ltc2992) Clamp threshold writes to hardware range
x86/efi: Fix graceful fault handling after FPU softirq changes
parisc: Fix IRQ leak in LASI driver
platform/chrome: cros_ec_typec: Init mutex in Thunderbolt registration
net: wwan: t7xx: validate port_count against message length in t7xx_port_enum_msg_handler
net/rds: handle zerocopy send cleanup before the message is queued
netpoll: pass buffer size to egress_dev() to avoid MAC truncation
net: libwx: use request_irq for VF misc interrupt
ip6_gre: Use cached t->net in ip6erspan_changelink().
net: libwx: fix VF illegal register access
pseries/papr-hvpipe: Fix the usage of copy_to_user()
pseries/papr-hvpipe: Fix & simplify error handling in papr_hvpipe_init()
pseries/papr-hvpipe: Prevent kernel stack memory leak to userspace
sound: ua101: fix division by zero at probe
perf/x86/intel: Improve validation and configuration of ACR masks
mptcp: pm: ADD_ADDR rtx: skip inactive subflows
net: rtnetlink: zero ifla_vf_broadcast to avoid stack infoleak in rtnl_fill_vfinfo
LoongArch: Fix SYM_SIGFUNC_START definition for 32BIT
mm/hugetlb_cma: round up per_node before logging it
arm64: signal: Preserve POR_EL0 if poe_context is missing
mtd: spi-nor: debugfs: fix out-of-bounds read in spi_nor_params_show()
KVM: arm64: Fix kvm_vcpu_initialized() macro parameter
fanotify: fix false positive on permission events
staging: vme_user: fix root device leak on init failure
spi: s3c64xx: fix NULL-deref on driver unbind
spi: zynqmp-gqspi: fix controller deregistration
spi: sun6i: fix controller deregistration
spi: ti-qspi: fix controller deregistration
spi: sun4i: fix controller deregistration
spi: syncuacer: fix controller deregistration
rust: allow `clippy::collapsible_if` globally
rust: allow `clippy::collapsible_match` globally
rust: drm: gem: clean up GEM state in init failure case
Bluetooth: L2CAP: Fix null-ptr-deref in l2cap_sock_get_sndtimeo_cb()
Bluetooth: L2CAP: Fix null-ptr-deref in l2cap_sock_state_change_cb()
Bluetooth: L2CAP: Fix null-ptr-deref in l2cap_sock_new_connection_cb()
Bluetooth: hci_event: Fix OOB read and infinite loop in hci_le_create_big_complete_evt
Bluetooth: btmtk: validate WMT event SKB length before struct access
Bluetooth: virtio_bt: validate rx pkt_type header length
Bluetooth: virtio_bt: clamp rx length before skb_put
LoongArch: KVM: Fix missing EMULATE_FAIL in kvm_emu_mmio_read()
selinux: prune /sys/fs/selinux/user
selinux: prune /sys/fs/selinux/disable
selinux: prune /sys/fs/selinux/checkreqprot
selinux: shrink critical section in sel_write_load()
selinux: don't reserve xattr slot when we won't fill it
selinux: use sk blob accessor in socket permission helpers
selinux: fix avdcache auditing
xfrm: ah: account for ESN high bits in async callbacks
ipv6: xfrm6: release dst on error in xfrm6_rcv_encap()
xfrm: defensively unhash xfrm_state lists in __xfrm_state_delete
xfrm: provide message size for XFRM_MSG_MAPPING
x86/efi: Restore IRQ state in EFI page fault handler
powerpc/kdump: fix KASAN sanitization flag for core_$(BITS).o
ALSA: seq: Fix UMP group 16 filtering
ALSA: core: Serialize deferred fasync state checks
ALSA: firewire-tascam: Do not drop unread control events
ALSA: hda/realtek: Fix speaker silence after S3 resume on Xiaomi Mi Laptop Pro 15
ALSA: pcm: oss: Fix data race at accessing runtime.oss.trigger
ALSA: hda: cs35l56: Propagate ASP TX source control errors
usb: typec: tcpm: fix debug accessory mode detection for sink ports
usb: ulpi: fix memory leak on ulpi_register() error paths
USB: serial: option: add Telit Cinterion LE910Cx compositions
USB: omap_udc: DMA: Don't enable burst 4 mode
ALSA: usb-audio: Fix UAC3 cluster descriptor size check
ALSA: usb-audio: Avoid potential endless loop in convert_chmap_v3()
ALSA: usb-audio: midi2: Restart output URBs on resume
usb: usblp: fix uninitialized heap leak via LPGETSTATUS ioctl
usb: usblp: fix heap leak in IEEE 1284 device ID via short response
wifi: brcmfmac: Fix potential use-after-free issue when stopping watchdog task
wifi: b43: enforce bounds check on firmware key index in b43_rx()
wifi: mac80211: remove station if connection prep fails
wifi: ath5k: do not access array OOB
wifi: mac80211: use safe list iteration in radar detect work
wifi: rsi: fix kthread lifetime race between self-exit and external-stop
wifi: mac80211: drop stray 'static' from fast-RX rx_result
wifi: b43legacy: enforce bounds check on firmware key index in RX path
wifi: mt76: mt7921: fix ROC abort flow interruption in mt7921_roc_work
wifi: mt76: mt7921: fix a potential clc buffer length underflow
wifi: mt76: mt7925: fix incorrect length field in txpower command
wifi: mt76: mt7925: fix AMPDU state handling in mt7925_tx_check_aggr
exit: prevent preemption of oopsing TASK_DEAD task
net/sched: sch_red: Replace direct dequeue call with peek and qdisc_dequeue_peeked
net: stmmac: Disable EEE RX clock stop when VLAN is enabled
KVM: SVM: check validity of VMCB controls when returning from SMM
net: af_key: zero aligned sockaddr tail in PF_KEY exports
smb: client/smbdirect: fix MR registration for coalesced SG lists
mptcp: sync the msk->sndbuf at accept() time
flow_dissector: do not dissect PPPoE PFC frames
ceph: fix num_ops off-by-one when crypto allocation fails
KVM: x86: Fix shadow paging use-after-free due to unexpected GFN
ksmbd: rewrite stop_sessions() with restartable iteration
spi: rockchip: fix controller deregistration
wifi: mt76: mt7925: fix incorrect TLV length in CLC command
ASoC: SOF: Don't allow pointer operations on unconfigured streams
iommufd: Fix a race with concurrent allocation and unmap
tracepoint: balance regfunc() on func_add() failure in tracepoint_add_func()
ACPI: video: force native backlight on HP OMEN 16 (8A44)
ACPI: CPPC: Fix related_cpus inconsistency during CPU hotplug
ACPI: video: Add backlight=native quirk for Dell OptiPlex 7770 AIO
ACPI: scan: Use acpi_dev_put() in object add error paths
fbdev: udlfb: add vm_ops to dlfb_ops_mmap to prevent use-after-free
ipmi:si: Return state to normal if message allocation fails
ipmi: Check event message buffer response for bad data
ipmi: Add limits to event and receive message requests
scsi: target: configfs: Bound snprintf() return in tg_pt_gp_members_show()
BACKPORT: phy: qcom: edp: Add PHY-specific LDO config for eDP low vdiff
BACKPORT: phy: qcom: edp: Fix AUX_CFG8 programming for DP mode
BACKPORT: phy: qcom: edp: Add SC7280/SC8180X swing/pre-emphasis tables
BACKPORT: phy: qcom: edp: Add eDP/DP mode switch support
BACKPORT: phy: qcom: edp: Unify generic DP/eDP swing and pre-emphasis tables
BACKPORT: phy: qcom: edp: Fix NULL pointer dereference for phy v6 (x1e80100)
BACKPORT: phy: qcom: edp: Add Glymur platform support
BACKPORT: phy: qcom-qmp: qserdes-com: Add v8 DP-specific qserdes register offsets
BACKPORT: phy: qcom: edp: Fix the DP_PHY_AUX_CFG registers count
FROMLIST: dt-bindings: phy: qcom-edp: Add reference clock for sa8775p eDP PHY
BACKPORT: dt-bindings: phy: Add DP PHY compatible for Glymur
Revert "FROMLIST: dt-bindings: phy: qcom-edp: Add eDP ref clk for sa8775p"
Revert "FROMLIST: phy: qcom: edp: Initialize swing_pre_emph_cfg for sc7280"
FROMLIST: fastrpc: Reduce log level for DSP info and reserved memory messages
PENDING: arm64: dts: qcom: talos: enable video codec on Talos
PENDING: media: qcom: venus: support PAS boot and flexible IOMMU handling
PENDING: dt-bindings: media: qcom: venus: add iommu-map support
FROMLIST: arm64: dts: qcom: purwa: Add EL2 overlay for purwa-iot-evk
QCLINUX: qcom.config: Rename CONFIG_CORESIGHT_TGU to CONFIG_QCOM_TGU
FROMLIST: qcom-tgu: Add reset node to initialize
FROMLIST: qcom-tgu: Add timer/counter functionality for TGU
FROMLIST: qcom-tgu: Add support to configure next action
FROMLIST: qcom-tgu: Add TGU decode support
FROMLIST: qcom-tgu: Add signal priority support
FROMLIST: qcom-tgu: Add TGU driver
FROMLIST: dt-bindings: arm: Add support for Qualcomm TGU trace
Revert "FROMLIST: dt-bindings: arm: Add support for Coresight TGU trace"
Revert "FROMLIST: coresight: Add coresight TGU driver"
Revert "FROMLIST: coresight-tgu: Add signal priority support"
Revert "FROMLIST: coresight-tgu: Add TGU decode support"
Revert "FROMLIST: coresight-tgu: add support to configure next action"
Revert "FROMLIST: coresight-tgu: add timer/counter functionality for TGU"
Revert "FROMLIST: coresight-tgu: add reset node to initialize"
FROMLIST: wifi: ath11k: add MSDU length validation for TKIP MIC error
FROMLIST: wifi: ath11k: fix invalid data access in ath11k_dp_rx_h_undecap_nwifi
FROMLIST: wifi: ath12k: fix memory leak in ath12k_wifi7_dp_rx_h_verify_tkip_mic()
Linux 6.18.29
rxrpc: Also unshare DATA/RESPONSE packets when paged frags are present
Linux 6.18.28
xfrm: esp: avoid in-place decrypt on shared skb frags
Linux 6.18.27
ipmi:ssif: NULL thread on error
ipmi:ssif: Remove unnecessary indention
netfilter: reject zero shift in nft_bitwise
net: ipv6: fix NOREF dst use in seg6 and rpl lwtunnels
mm/slab: return NULL early from kmalloc_nolock() in NMI on UP
mm/page_alloc: return NULL early from alloc_frozen_pages_nolock() in NMI on UP
vmalloc: fix buffer overflow in vrealloc_node_align()
ALSA: aloop: Fix peer runtime UAF during format-change stop
ALSA: caiaq: fix usb_dev refcount leak on probe failure
drm/amdgpu: fix zero-size GDS range init on RDNA4
ipv6: rpl: reserve mac_len headroom when recompressed SRH grows
ALSA: caiaq: Don't abort when no input device is available
ALSA: caiaq: Fix potentially leftover ep1_in_urb at error path
driver core: Add kernel-doc for DEV_FLAG_COUNT enum value
crypto: authencesn - reject short ahash digests during instance creation
net: qrtr: ns: Limit the total number of nodes
net: qrtr: ns: Limit the maximum number of lookups
net: qrtr: ns: Limit the maximum server registration per node
iio: frequency: admv1013: fix NULL pointer dereference on str
iio: frequency: admv1013: add dev variable
media: rc: igorplugusb: heed coherency rules
media: rc: ttusbir: respect DMA coherency rules
wifi: mt76: mt792x: fix mt7925u USB WFSYS reset handling
wifi: mt76: mt792x: describe USB WFSYS reset with a descriptor
phy: qcom: m31-eusb2: clear PLL_EN during init
phy: qcom: m31-eusb2: Update init sequence to set PHY_ENABLE
mei: me: add nova lake point H DID
mei: me: use PCI_DEVICE_DATA macro
lib: test_hmm: evict device pages on file close to avoid use-after-free
arm64: mm: Fix rodata=full block mapping support for realm guests
arm64: mm: Simplify check in arch_kfence_init_pool()
mm: prevent droppable mappings from being locked
seg6: fix seg6 lwtunnel output redirect for L2 reduced encap mode
scsi: sd: fix missing put_disk() when device_add(&disk_dev) fails
sched_ext: Documentation: Clarify ops.dispatch() role in task lifecycle
rxgk: Fix potential integer overflow in length check
rtmutex: Use waiter::task instead of current in remove_waiter()
ntfs3: fix integer overflow in run_unpack() volume boundary check
ntfs3: add buffer boundary checks to run_unpack()
NFSv4.1: Apply session size limits on clone path
ktest: Fix the month in the name of the failure directory
IB/core: Fix zero dmac race in neighbor resolution
gtp: disable BH before calling udp_tunnel_xmit_skb()
ceph: only d_add() negative dentries when they are unhashed
dm mirror: fix integer overflow in create_dirty_log()
crypto: nx - Fix packed layout in struct nx842_crypto_header
crypto: nx - fix context leak in nx842_crypto_free_ctx
crypto: nx - fix bounce buffer leaks in nx842_crypto_{alloc,free}_ctx
crypto: atmel-sha204a - Fix uninitialized data access on OTP read error
crypto: atmel-sha204a - Fix potential UAF and memory leak in remove path
crypto: atmel-sha204a - Fix error codes in OTP reads
crypto: atmel-tdes - fix DMA sync direction
crypto: ccree - fix a memory leak in cc_mac_digest()
crypto: hisilicon - Fix dma_unmap_single() direction
crypto: atmel-ecc - Release client on allocation failure
crypto: atmel-aes - Fix 3-page memory leak in atmel_aes_buff_cleanup
crypto: arm64/aes - Fix 32-bit aes_mac_update() arg treated as 64-bit
crypto: acomp - fix wrong pointer stored by acomp_save_req()
can: ucan: fix devres lifetime
bus: mhi: host: pci_generic: Switch to async power up to avoid boot delays
Bluetooth: hci_event: fix potential UAF in SSP passkey handlers
apparmor: use target task's context in apparmor_getprocattr()
mfd: core: Preserve OF node when ACPI handle is present
taskstats: set version in TGID exit notifications
tcp: call sk_data_ready() after listener migration
wifi: rtl8xxxu: fix potential use of uninitialized value
x86/shstk: Prevent deadlock during shstk sigreturn
x86/cpu: Disable FRED when PTI is forced on
inotify: fix watch count leak when fsnotify_add_inode_mark_locked() fails
HID: apple: ensure the keyboard backlight is off if suspending
check-uapi: link into shared objects
md/raid5: validate payload size before accessing journal metadata
md/raid5: fix soft lockup in retry_aligned_read()
md/md-llbitmap: raise barrier before state machine transition
md/md-llbitmap: skip reading rdevs that are not in_sync
amdgpu/jpeg: fix deepsleep register for jpeg 5_0_0 and 5_0_2
mtd: spinand: winbond: Declare the QE bit on W25NxxJW
mtd: spi-nor: sst: Fix write enable before AAI sequence
ext4: fix missing brelse() in ext4_xattr_inode_dec_ref_all()
ext4: fix bounds check in check_xattrs() to prevent out-of-bounds access
ring-buffer: Do not double count the reader_page
ARM: 9472/1: fix race condition on PG_dcache_clean in __sync_icache_dcache()
perf annotate: Use jump__delete when freeing LoongArch jumps
KVM: nSVM: Always intercept VMMCALL when L2 is active
KVM: nSVM: Raise #UD if unhandled VMMCALL isn't intercepted by L1
KVM: nSVM: Add missing consistency check for nCR3 validity
KVM: nSVM: Drop the non-architectural consistency check for NP_ENABLE
KVM: nSVM: Add missing consistency check for EFER, CR0, CR4, and CS
KVM: nSVM: Clear tracking of L1->L2 NMI and soft IRQ on nested #VMEXIT
KVM: nSVM: Clear EVENTINJ fields in vmcb12 on nested #VMEXIT
KVM: nSVM: Clear GIF on nested #VMEXIT(INVALID)
KVM: nSVM: Triple fault if mapping VMCB12 fails on nested #VMEXIT
KVM: nSVM: Refactor writing vmcb12 on nested #VMEXIT as a helper
KVM: nSVM: Refactor checking LBRV enablement in vmcb12 into a helper
KVM: nSVM: Always inject a #GP if mapping VMCB12 fails on nested VMRUN
KVM: SVM: Add missing save/restore handling of LBR MSRs
KVM: SVM: Switch svm_copy_lbrs() to a macro
KVM: nSVM: Delay setting soft IRQ RIP tracking fields until vCPU run
KVM: nSVM: Avoid clearing VMCB_LBR in vmcb12
KVM: nSVM: Use vcpu->arch.cr2 when updating vmcb12 on nested #VMEXIT
KVM: nSVM: Delay stuffing L2's current RIP into NextRIP until vCPU run
KVM: nSVM: Always use NextRIP as vmcb02's NextRIP after first L2 VMRUN
KVM: nSVM: Ensure AVIC is inhibited when restoring a vCPU to guest mode
KVM: SVM: Explicitly mark vmcb01 dirty after modifying VMCB intercepts
KVM: SVM: Inject #UD for INVLPGA if EFER.SVME=0
KVM: nSVM: Sync interrupt shadow to cached vmcb12 after VMRUN of L2
KVM: nSVM: Sync NextRIP to cached vmcb12 after VMRUN of L2
KVM: nSVM: Mark all of vmcb02 dirty when restoring nested state
KVM: x86: Defer non-architectural deliver of exception payload to userspace read
LoongArch: KVM: Use CSR_CRMD_PLV in kvm_arch_vcpu_in_kernel()
userfaultfd: allow registration of ranges below mmap_min_addr
mm/damon/core: use time_in_range_open() for damos quota window start
mm/damon/core: validate damos_quota_goal->nid for node_mem_{used,free}_bp
mm/damon/stat: fix memory leak on damon_start() failure in damon_stat_start()
mm/mempolicy: fix memory leaks in weighted_interleave_auto_store()
mm/vmalloc: take vmap_purge_lock in shrinker
rtc: ntxec: fix OF node reference imbalance
tpm: tpm_tis: stop transmit if retries are exhausted
tpm: tpm_tis: add error logging for data transfer
tpm: Use kfree_sensitive() to free auth session in tpm_dev_release()
tpm: Fix auth session leak in tpm2_get_random() error path
tpm2-sessions: Fix missing tpm_buf_destroy() in tpm2_read_public()
pwm: imx-tpm: Count the number of enabled channels in probe
crypto: talitos - rename first/last to first_desc/last_desc
crypto: talitos - fix SEC1 32k ahash request limitation
firmware: google: framebuffer: Do not unregister platform device
xfs: fix a resource leak in xfs_alloc_buftarg()
xfs: start gc on zonegc_low_space attribute updates
crypto: qat - fix IRQ cleanup on 6xxx probe failure
arm64: dts: ti: am62-verdin: Enable pullup for eMMC data pins
mmc: sdhci-of-dwcmshc: Disable clock before DLL configuration
mmc: block: use single block write in retry
randomize_kstack: Maintain kstack_offset per task
hwmon: (pt5161l) Fix bugs in pt5161l_read_block_data()
ASoC: Intel: avs: replace strcmp with sysfs_streq
drm/amd: Fix set but not used warnings
fs: prepare for adding LSM blob to backing_file
hwmon: (isl28022) Fix integer overflow in power calculation on 32-bit
power: supply: axp288_charger: Do not cancel work before initializing it
LoongArch: Show CPU vulnerabilites correctly
tpm: avoid -Wunused-but-set-variable
extract-cert: Wrap key_pass with '#ifdef USE_PKCS11_ENGINE'
spi: fix resource leaks on device setup failure
libceph: Prevent potential null-ptr-deref in ceph_handle_auth_reply()
ipv4: icmp: validate reply type before using icmp_pointers
RDMA/rxe: Validate pad and ICRC before payload_size() in rxe_rcv
tracing/fprobe: Reject registration of a registered fprobe before init
slub: fix data loss and overflow in krealloc()
drm/arcpgu: fix device node leak
net: ks8851: Avoid excess softirq scheduling
net: mctp: fix don't require received header reserved bits to be zero
netconsole: avoid out-of-bounds access on empty string in trim_newline()
net: bridge: use a stable FDB dst snapshot in RCU readers
net: ks8851: Reinstate disabling of BHs around IRQ handler
net/smc: avoid early lgr access in smc_clc_wait_msg
net: txgbe: fix firmware version check
net: rds: fix MR cleanup on copy error
net: qrtr: ns: Free the node during ctrl_cmd_bye()
arm64: dts: marvell: uDPU: add ethernet aliases
net: txgbe: fix RTNL assertion warning when remove module
tools/accounting: handle truncated taskstats netlink messages
EDAC/versalnet: Fix memory leak in remove and probe error paths
rxrpc: Fix rxrpc_input_call_event() to only unshare DATA packets
rxrpc: Fix re-decryption of RESPONSE packets
rxrpc: Fix error handling in rxgk_extract_token()
rxrpc: Fix rxkad crypto unalignment handling
rxrpc: Fix conn-level packet handling to unshare RESPONSE packets
rxrpc: Fix memory leaks in rxkad_verify_response()
rxrpc: Fix potential UAF after skb_unshare() failure
iio: adc: ad7768-1: remove switch to one-shot mode
iio: adc: ad7768-1: fix one-shot mode data acquisition
ALSA: pcmtest: Fix resource leaks in module init error paths
ALSA: pcmtest: fix reference leak on failed device registration
ALSA: hda/realtek - Add mute LED support for HP Victus 15-fa2xxx
ALSA: 6fire: Fix input volume change detection
ALSA: caiaq: Handle probe errors properly
ALSA: caiaq: Fix control_put() result and cache rollback
ALSA: core: Fix potential data race at fasync handling
io_uring/poll: ensure EPOLL_ONESHOT is propagated for EPOLL_URING_WAKE
io_uring/poll: fix signed comparison in io_poll_get_ownership()
iio: adc: ti-ads7950: use iio_push_to_buffers_with_ts_unaligned()
block: relax pgmap check in bio_add_page for compatible zone device pages
io_uring/timeout: check unused sqe fields
block: fix zone write plugs refcount handling in disk_zone_wplug_schedule_bio_work()
rbd: fix null-ptr-deref when device_add_disk() fails
selftests/landlock: Skip stale records in audit_match_record()
selftests/landlock: Fix snprintf truncation checks in audit helpers
selftests/landlock: Fix format warning for __u64 in net_test
selftests/landlock: Drain stale audit records on init
landlock: Fix LOG_SUBDOMAINS_OFF inheritance across fork()
selftests/mqueue: Fix incorrectly named file
sched: Use u64 for bandwidth ratio calculations
reset: rzv2h-usb2phy: Keep PHY clock enabled for entire device lifetime
remoteproc: xlnx: Only access buffer information if IPI is buffered
RDMA/mana_ib: Disable RX steering on RSS QP destroy
PCI: cadence: Use cdns_pcie_read_sz() for byte or word read access
parisc: Drop ip_fast_csum() inline assembly implementation
parisc: _llseek syscall is only available for 32-bit userspace
nvme: respect NVME_QUIRK_DISABLE_WRITE_ZEROES when wzsl is set
nvme-pci: add NVME_QUIRK_DISABLE_WRITE_ZEROES for Kingston OM3SGP4
mtd: docg3: fix use-after-free in docg3_release()
mm/hugetlb: fix early boot crash on parameters without '=' separator
mm/damon/core: fix damon_call() vs kdamond_fn() exit race
mm/alloc_tag: clear codetag for pages allocated before page_ext initialization
mfd: stpmic1: Attempt system shutdown twice in case PMIC is confused
io_uring/register: fix ring resizing with mixed/large SQEs/CQEs
md/raid10: fix deadlock with check operation and nowait requests
KVM: selftests: Fix reserved value WRMSR testcase for multi-feature MSRs
jbd2: fix deadlock in jbd2_journal_cancel_revoke()
ipmi:ssif: Clean up kthread on errors
erofs: fix the out-of-bounds nameoff handling for trailing dirents
ALSA: seq_oss: return full count for successful SEQ_FULLSIZE writes
ALSA: ctxfi: Add fallback to default RSR for S/PDIF
ALSA: aoa: Skip devices with no codecs in i2sbus_resume()
ALSA: aoa: i2sbus: fix OF node lifetime handling
ALSA: aoa: i2sbus: clear stale prepared state
mm/zsmalloc: copy KMSAN metadata in zs_page_migrate()
ext2: reject inodes with zero i_nlink and valid mode in ext2_iget()
net: qrtr: ns: Fix use-after-free in driver remove()
media: i2c: imx219: Check return value of devm_gpiod_get_optional() in imx219_probe()
lib/ts_kmp: fix integer overflow in pattern length calculation
PCI: epf-mhi: Return 0, not remaining timeout, when eDMA ops complete
Revert "ALSA: usb: Increase volume range that triggers a warning"
PCI: endpoint: pci-epf-ntb: Remove duplicate resource teardown
crypto: atmel-sha204a - Fix OTP sysfs read and error handling
media: mtk-jpeg: fix use-after-free in release path due to uncancelled work
net: strparser: fix skb_head leak in strp_abort_strp()
net: caif: clear client service pointer on teardown
ALSA: control: Validate buf_len before strnlen() in snd_ctl_elem_init_enum_names()
media: amphion: Fix race between m2m job_abort and device_run
PCI: imx6: Skip waiting for L2/L3 Ready on i.MX6SX
EDAC/versalnet: Fix device_node leak in mc_probe()
hwmon: (powerz) Fix missing usb_kill_urb() on signal interrupt
of: unittest: fix use-after-free in testdrv_probe()
of: unittest: fix use-after-free in of_unittest_changeset()
dt-bindings: display: ti, am65x-dss: Fix AM62L DSS reg and clock constraints
crypto: pcrypt - Fix handling of MAY_BACKLOG requests
crypto: algif_aead - snapshot IV for async AEAD requests
mm: call ->free_folio() directly in folio_unmap_invalidate()
spi: ch341: fix memory leaks on probe failures
spi: imx: fix use-after-free on unbind
thermal: core: Fix thermal zone governor cleanup issues
um: drivers: call kernel_strrchr() explicitly in cow_user.c
vfio/cdx: Fix NULL pointer dereference in interrupt trigger path
vfio/cdx: Serialize VFIO_DEVICE_SET_IRQS with a per-device mutex
vfio/virtio: Convert list_lock from spinlock to mutex
vfio: selftests: Fix VLA initialisation in vfio_pci_irq_set()
wifi: mwifiex: fix use-after-free in mwifiex_adapter_cleanup()
wifi: rtw88: check for PCI upstream bridge existence
zram: do not forget to endio for partial discard requests
Input: edt-ft5x06 - fix use-after-free in debugfs teardown
ocfs2: split transactions in dio completion to avoid credit exhaustion
mm: migrate: requeue destination folio on deferred split queue
arm64/mm: Enable batched TLB flush in unmap_hotplug_range()
firmware: google: framebuffer: Do not mark framebuffer as busy
fs: afs: revert mmap_prepare() change
kbuild: rust: allow `clippy::uninlined_format_args`
rust: dma: remove DMA_ATTR_NO_KERNEL_MAPPING from public attrs
drm/nouveau: fix nvkm_device leak on aperture removal failure
device property: Make modifications of fwnode "flags" thread safe
driver core: Don't let a device probe until it's ready
ibmasm: fix heap over-read in ibmasm_send_i2o_message()
ibmasm: fix OOB reads in command_file_write due to missing size checks
misc: ibmasm: fix OOB MMIO read in ibmasm_handle_mouse_interrupt()
greybus: gb-beagleplay: fix sleep in atomic context in hdlc_tx_frames()
greybus: gb-beagleplay: bound bootloader receive buffering
leds: qcom-lpg: Check for array overflow when selecting the high resolution
drm/nouveau: fix u32 overflow in pushbuf reloc bounds check
LoongArch: Add spectre boundry for syscall dispatch table
ALSA: usb-audio: Evaluate packsize caps at the right place
usb: chipidea: core: allow ci_irq_handler() handle both ID and VBUS change
usb: chipidea: otg: not wait vbus drop if use role_switch
usb: xhci: Make usb_host_endpoint.hcpriv survive endpoint_disable()
ALSA: usb-audio: Fix Audio Advantage Micro II SPDIF switch
ALSA: usb-audio: Avoid false E-MU sample-rate notifications
ALSA: usb-audio: stop parsing UAC2 rates at MAX_NR_RATES
FROMLIST: Bluetooth: hci_sync: Add LE Channel Sounding HCI Command/event structures 1. Implement LE Event Mask to include events required for    LE Channel Sounding 2. Enable Channel Sounding feature bit in the    LE Host Supported Features command 3. Define HCI command and event structures necessary for    LE Channel Sounding functionality
FROMLIST: arm64: dts: qcom: monaco: add GDSP fastrpc-compute-cb nodes
Linux 6.18.26
Buffer overflow in drivers/xen/sys-hypervisor.c
xen/privcmd: fix double free via VMA splitting
FROMLIST: wifi: ath12k: fix peer_id usage in normal RX path
FROMLIST: wifi: ath12k: add channel 177 to the 5 GHz channel list