### PR TITLE
linux-qcom-6.18 : update to tag qcom-6.18.y-20260611 v6.18.30

### DIFF
--- a/recipes-kernel/linux/linux-qcom_6.18.bb
+++ b/recipes-kernel/linux/linux-qcom_6.18.bb
@@ -8,14 +8,14 @@ inherit kernel cml1
 
 COMPATIBLE_MACHINE = "(qcom)"
 
-LINUX_VERSION ?= "6.18.25"
+LINUX_VERSION ?= "6.18.30"
 
 PV = "${LINUX_VERSION}"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/linux-qcom-6.18:"
 
-# tag:qcom-6.18.y-20260515
-SRCREV ?= "9a4537ba60cc7332c642471323e32f85df771053"
+# tag:qcom-6.18.y-20260611
+SRCREV ?= "d58ad5c480fa06f04fff90d42ad0367ea093bc7f"
 
 SRCBRANCH ?= "nobranch=1"
 SRCBRANCH:class-devupstream ?= "branch=qcom-6.18.y"


### PR DESCRIPTION
Move to the latest linux-qcom-6.18 release tag qcom-6.18.y-20260611

Changelog:
drm/panel: Add driver for DLC DLC0697 DSI panel (#677)
misc: fastrpc: Enable poll mode for specific devices (#598)
Add display (dt-binding/driver) support for shikra (#673)
misc: fastrpc: Add cache maintenance for non-coherent platforms (#663)
arm64: configs: qcom.config: Enable LZ4 backend for zram (#683)
clk: qcom: Add AUDIOCORECC/DISPCC/GPUCC support for the Qualcomm Shikra SoC (#655)
Fix MST RB8 irq/payload issue (#667)
Add support for Qualcomm TSCSS hardware (#656)
Clk gp mnd (#657)
arm64: dts: qcom: talos-evk: fix sdhc_2 vqmmc-supply for UH… (#676)
arm64: dts: qcom: monaco-evk: disable unused camera regulators (#665)
Add CAMSS and IMX577 sensor support for Shikra EVK (#668)
rpmsg: glink: Make glink smem interrupt wakeup capable (#674)
PCI: dwc/qcom: Rework dw_pcie_wait_for_link() error handling and add D3cold support (#644)
Fix GPU blocking XO Shutdown on QLI2.0 (#658)
arm64: dts: qcom: talos-evk: add QPS615 m.2 ethernet staging overlay (#659)
arm64: dts: qcom: added ife lite cpas to purwa camera dtsi (#660)
Enable IPCB for Hamoa and Glymur (#602)
arm64: dts: qcom: Fix GPIO free and acquire logic (#607)
arm64: configs: qcom.config: Enable CONFIG_SWIOTLB_DYNAMIC (#642)
arm64: dts: qcom: Change Purwa camera firmware path#638
misc: fastrpc: fix context leak and hang on signal-interrupted invoke (#637)
ras: aest: extend AEST support to Device Tree frontend (#603)
mmc: sdhci-msm: Set ice clk rate (#632)
media: iris: Platform data refactoring and Gen2 firmware autodetect (#622)
scsi: ufs: ufs-qcom: Enable SKIP DEVICE RESET Quirk (#641)
misc: fastrpc: Add missing bug fixes (#624)
Bluetooth: hci_qca: Use 100 ms SSR delay for rampatch and NVM loading (#631)
serial: qcom_geni: Fix RX DMA stall when SE_DMA_RX_LEN_IN is zero (#626)
Bluetooth: add QCC2072 M.2 support for Qualcomm qcs6490-rb3gen2 industrial mezzanine board (#634)
arm64: dts: qcom: qcs615-ride: fix sdhc_2 vqmmc supply for UHS-I mode (#620)
Update TSENS thermal zone (#615)
Add interconnect node for Lemans, Monaco, Kodiak, Talos (#616)
arm64: dts: qcom: lemans: enable EUD support (#543)
wifi: ath11k: raise max vdevs to 4 on hardware with P2P and dual-station support (#612)
misc: fastrpc: fix use-after-free of fastrpc_user in workqueue context (#594)
Add Shikra Support (#613)
iommu/arm-smmu: Add interconnect bandwidth voting support (#590)
arm64: dts: qcom: add Purwa CAMX EL2 overlay (#610)
ath12k: fix peer_id usage in normal RX path (#524)
Merge tag 'v6.18.30' into qcom-6.18.y (#586)
arm64: configs: Add Linux software RAID support (#519)
arm64: dts: qcom: qcs6490-rb3gen2: Add WCD headset playback and record for qcs6490-rb3gen2 industrial mezzanine (#512)
arm64: dts: qcom: add hamoa CAMX EL2 overlay (#587)
fastrpc: Reduce log level for DSP info and reserved memory messages (#581)
genirq/ath12k: fallback to threaded NAPI when IRQ affinity is unavailable (#595)
phy: qcom: edp: Backport eDP/DP PHY fixes and platform support (#568)
Bluetooth: hci_qca: Fix missing wakeup during SSR memdump handling (#577)
Bluetooth: hci_qca: Convert timeout from jiffies to ms (#578)
Enable ETR and CTCU devices for Monaco (#583)
arm64: dts: qcom: monaco: add GDSP fastrpc-compute-cb nodes (#529)
wifi: ath11k/ath12k: dp rx sanity checks for invalid length in error paths (#564)
arm64: dts: qcom: purwa: Add EL2 overlay for purwa-iot-evk (#570)
Update TGU driver to the latest upstream version (#563)
Bluetooth: hci_sync: Add LE Channel Sounding HCI Command/ev… (#535)
enable kvm feature for the venus on Talos (#580)