### PR TITLE
linux-qcom-6.18 : update to tag qcom-6.18.y-20260615 v6.18.30

### DIFF
--- a/recipes-kernel/linux/linux-qcom_6.18.bb
+++ b/recipes-kernel/linux/linux-qcom_6.18.bb
@@ -16,8 +16,8 @@ PV = "${LINUX_VERSION}"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/linux-qcom-6.18:"
 
-# tag:qcom-6.18.y-20260611
-SRCREV ?= "d58ad5c480fa06f04fff90d42ad0367ea093bc7f"
+# tag:qcom-6.18.y-20260615
+SRCREV ?= "360986b713f88d182fb17fdf5decedf665a77834"
 
 SRCBRANCH ?= "nobranch=1"
 SRCBRANCH:class-devupstream ?= "branch=qcom-6.18.y"


### PR DESCRIPTION
Move to the latest linux-qcom-6.18 release tag qcom-6.18.y-20260615

Changelog:
WORKAROUND: Move CPU PM notifier registration to Probe
FROMLIST: arm64: defconfig: Enable Qualcomm BAM-DMUX WWAN driver
FROMLIST: arm64: dts: qcom: shikra: Add BAM-DMUX support
FROMLIST: dmaengine: qcom: bam_dma: Defer IRQ trigger type to device tree
FROMLIST: soc: qcom: smsm: Increase SMSM_DEFAULT_NUM_HOSTS to 5
FROMLIST: interconnect: qcom: Enable Shikra interconnect driver by default for ARCH_QCOM
BACKPORT: FROMLIST: dt-bindings: interconnect: qcom,osm-l3: Add EPSS L3 DT binding for Qualcomm Shikra SoC
FROMLIST: arm64: defconfig: Enable USB_UAS in arm64 configuration
FROMLIST: usb: dwc3: Update nominal max votes for qcom usb
QCLINUX: arm64: configs: qcom: Set DRIVER_DEFERRED_PROBE_TIMEOUT to 60
BACKPORT: Documentation: update deferred_probe_timeout cmdline parameter documentation
BACKPORT: driver core: Make deferred_probe_timeout default a Kconfig option
UPSTREAM: clk: qcom: rpmh: Define RPMH_IPA_CLK on QCS615
UPSTREAM: dt-bindings: interconnect: qcom,qcs615-rpmh: Drop IPA interconnects
UPSTREAM: arm64: dts: qcom: qcs615: Drop IPA interconnects
FROMLIST: arm64: dts: qcom: shikra-evk: Enable Iris core
FROMLIST: arm64: dts: qcom: shikra: Add Iris video codec node
FROMLIST: media: iris: constify inst_fw_cap_sm8250_dec
FROMLIST: media: venus: skip QCM2290 if Iris driver is enabled
Revert "FROMLIST: media: venus: prefer iris driver for qcm2290 when IRIS is enabled"
FROMLIST: media: iris: add Gen2 firmware support on the Agatti platform
FROMLIST: media: iris: Introduce buffer size calculations for AR50LT
FROMLIST: media: iris: implement support for the Agatti platform
FROMLIST: media: iris: update buffer requirements based on received info
FROMLIST: media: iris: add minimal GET_PROPERTY implementation
FROMLIST: media: iris: Add framework support for AR50_LITE video core
FROMLIST: media: iris: skip PIPE if it is not supported by the platform
FROMLIST: media: iris: Add platform flag for instantaneous bandwidth voting
FROMLIST: media: iris: Add platform data field for watchdog interrupt mask
FROMLIST: media: iris: add vpu op hook to disable ARP buffer
FROMLIST: media: iris: Introduce interrupt_init as a vpu_op
FROMLIST: media: iris: Introduce set_preset_register as a vpu_op
FROMLIST: media: iris: Filter UBWC raw formats based on hardware capabilities
FROMLIST: media: iris: Skip UBWC configuration when not supported
FROMGIT: arm64: dts: qcom: lemans-pmics: enable rtc
PENDING: arm64: dts: qcom: hamoa: Enable CDSP cooling in staging dtso
WORKAROUND: ras: aest: Restore misc0 register on CPU idle exit